### PR TITLE
Use the /latest endpoint instead

### DIFF
--- a/docs/cheatsheet.rst
+++ b/docs/cheatsheet.rst
@@ -8,6 +8,7 @@ GitHub repos:
 
 - https://www.github.com/artefactual contains the main projects
 - https://www.github.com/artefactual-labs is a place for Artefactual staff to work on experiments
+- https://www.github.com/artefactual-sdps is the current home of Enduro and some related projects
 - https://www.github.com/archivematica host the Archivematica Issues repo and a few others Archivematica projects
 
 You might want to take a look at the `Artefactual YouTube channel <https://www.youtube.com/@ArtefactualSystems>`__.
@@ -21,7 +22,7 @@ Here is a table with relevant URLs, gathered together as a cheastsheet.
 .. list-table:: Resources for every project
 	:widths: 50 50 50 50
 	:header-rows: 1
-	
+
 	* - I am looking for...
 	  - AtoM
 	  - Archivematica
@@ -29,19 +30,19 @@ Here is a table with relevant URLs, gathered together as a cheastsheet.
 	* - GitHub repo
 	  - https://github.com/artefactual/atom
 	  - https://github.com/artefactual/archivematica
-	  - https://github.com/artefactual-labs/enduro
+	  - https://github.com/artefactual-sdps/enduro
 	* - The why and what of the project
 	  - https://www.accesstomemory.org/
 	  - https://www.archivematica.org/
-	  - https://enduroproject.netlify.app/docs/overview/whatisenduro/
+	  - https://enduro.readthedocs.io/
 	* - README
 	  - https://github.com/artefactual/atom/blob/qa/2.x/README.md
 	  - https://github.com/artefactual/archivematica/blob/qa/1.x/README.md
-	  - https://github.com/artefactual-labs/enduro/blob/main/README.md
+	  - https://github.com/artefactual-sdps/enduro/blob/main/README.md
 	* - License
 	  - https://github.com/artefactual/atom/blob/qa/2.x/LICENSE
 	  - https://github.com/artefactual/archivematica/blob/qa/1.x/LICENSE
-	  - https://github.com/artefactual-labs/enduro/blob/main/LICENSE
+	  - https://github.com/artefactual-sdps/enduro/blob/main/LICENSE
 	* - Code of Conduct
 	  - We think that the Code of Conduct should be the same for all projects - refer yourself to the one for Archivematica at https://github.com/artefactual/archivematica/blob/qa/1.x/CODE_OF_CONDUCT.md
 	  - https://github.com/artefactual/archivematica/blob/qa/1.x/CODE_OF_CONDUCT.md
@@ -49,23 +50,23 @@ Here is a table with relevant URLs, gathered together as a cheastsheet.
 	* - Contributing guide
 	  - https://github.com/artefactual/atom/blob/qa/2.x/CONTRIBUTING.md
 	  - https://github.com/artefactual/archivematica/blob/qa/1.x/CONTRIBUTING.md
-	  - https://enduroproject.netlify.app/docs/contribution-guidelines/
+	  - https://github.com/artefactual-sdps/enduro/blob/main/CONTRIBUTING.md
 	* - Issues
 	  - https://github.com/artefactual/atom/issues
 	  - https://github.com/archivematica/Issues/issues
-	  - 
+	  - https://github.com/artefactual-sdps/enduro/issues
 	* - How to install
 	  - https://github.com/artefactual/atom?tab=readme-ov-file#installation
 	  - https://github.com/artefactual/archivematica/blob/qa/1.x/README.md#installation
-	  - https://enduroproject.netlify.app/docs/
+	  - https://enduro.readthedocs.io/dev-manual/devel/ (dev only)
 	* - Quickstart
 	  - https://www.accesstomemory.org/docs/latest/#getting-started
 	  - https://www.archivematica.org/docs/latest/getting-started/quick-start/quick-start/#quick-start
-	  - https://enduroproject.netlify.app/docs/installation/
+	  - https://enduro.readthedocs.io/user-manual/
 	* - Release notes
 	  - https://github.com/artefactual/atom/releases
 	  - https://wiki.archivematica.org/Release_Notes
-	  - https://github.com/artefactual-labs/enduro/tags
+	  - None for now
 	* - Users group or mailing list
 	  - https://groups.google.com/g/ica-atom-users
 	  - https://groups.google.com/g/archivematica
@@ -77,20 +78,20 @@ Here is a table with relevant URLs, gathered together as a cheastsheet.
 	* - Documentation - user
 	  - https://www.accesstomemory.org/docs/latest/#user-manual
 	  - https://www.archivematica.org/docs/latest/#user-manual
-	  - https://enduroproject.netlify.app/docs/user-manual/
+	  - https://enduro.readthedocs.io/user-manual/
 	* - Documentation - developer
-	  - https://www.accesstomemory.org/fr/docs/2.8/#developer-s-manual
+	  - https://www.accesstomemory.org/docs/latest/#developer-s-manual
 	  - https://www.archivematica.org/docs/latest/#developer-manual
-	  - https://enduroproject.netlify.app/docs/development/
+	  - https://enduro.readthedocs.io/dev-manual/
 	* - Documentation - API
 	  - https://www.accesstomemory.org/docs/latest/#api
 	  - https://www.archivematica.org/docs/latest/dev-manual/api/api-overview/#api-overview
-	  - https://enduroproject.netlify.app/docs/api/
+	  - None for now
 	* - Architectural Decisions Record (ADR)
 	  - None for now
 	  - https://adr.archivematica.org/
 	  - None for now
 	* - SlideShare
 	  - https://www.slideshare.net/accesstomemory
-	  - https://fr.slideshare.net/Archivematica/presentations
+	  - https://slideshare.net/Archivematica/presentations
 	  - None for now

--- a/docs/cheatsheet.rst
+++ b/docs/cheatsheet.rst
@@ -59,8 +59,8 @@ Here is a table with relevant URLs, gathered together as a cheastsheet.
 	  - https://github.com/artefactual/archivematica/blob/qa/1.x/README.md#installation
 	  - https://enduroproject.netlify.app/docs/
 	* - Quickstart
-	  - https://www.accesstomemory.org/fr/docs/2.8/#getting-started
-	  - https://www.archivematica.org/fr/docs/archivematica-1.15/getting-started/quick-start/quick-start/#quick-start
+	  - https://www.accesstomemory.org/docs/latest/#getting-started
+	  - https://www.archivematica.org/docs/latest/getting-started/quick-start/quick-start/#quick-start
 	  - https://enduroproject.netlify.app/docs/installation/
 	* - Release notes
 	  - https://github.com/artefactual/atom/releases
@@ -75,16 +75,16 @@ Here is a table with relevant URLs, gathered together as a cheastsheet.
 	  - https://wiki.archivematica.org/Main_Page - not currently used, for reference only
 	  - None
 	* - Documentation - user
-	  - https://www.accesstomemory.org/fr/docs/2.8/#user-manual
-	  - https://www.archivematica.org/fr/docs/archivematica-1.15/#user-manual
+	  - https://www.accesstomemory.org/docs/latest/#user-manual
+	  - https://www.archivematica.org/docs/latest/#user-manual
 	  - https://enduroproject.netlify.app/docs/user-manual/
 	* - Documentation - developer
 	  - https://www.accesstomemory.org/fr/docs/2.8/#developer-s-manual
-	  - https://www.archivematica.org/fr/docs/archivematica-1.15/#developer-manual
+	  - https://www.archivematica.org/docs/latest/#developer-manual
 	  - https://enduroproject.netlify.app/docs/development/
 	* - Documentation - API
-	  - https://www.accesstomemory.org/fr/docs/2.8/#api
-	  - https://www.archivematica.org/fr/docs/archivematica-1.15/dev-manual/api/api-overview/#api-overview
+	  - https://www.accesstomemory.org/docs/latest/#api
+	  - https://www.archivematica.org/docs/latest/dev-manual/api/api-overview/#api-overview
 	  - https://enduroproject.netlify.app/docs/api/
 	* - Architectural Decisions Record (ADR)
 	  - None for now

--- a/docs/i18n.rst
+++ b/docs/i18n.rst
@@ -16,7 +16,7 @@ For the AtoM, here is `more information about contributing documentation transla
 User interface
 ______________
 
-In AtoM documentation, there is a `Translate section <https://accesstomemory.org/fr/docs/2.8/#translate>`__ on how to translate both database contents and user interface elements in AtoM.
+In AtoM documentation, there is a `Translate section <https://accesstomemory.org/docs/latest/#translate>`__ on how to translate both database contents and user interface elements in AtoM.
 
 Archivematica
 -------------
@@ -29,7 +29,7 @@ At the moment speaking, there is a partial translation of Archivematica translat
 User interface
 ______________
 
-We are not currently working on translations for the Archivematica UI, in date of March 2024. You can `access previous documentation for translating the AM user interaface <https://archivematica.org/fr/docs/archivematica-1.15/user-manual/translations/translations/>`.
+We are not currently working on translations for the Archivematica UI, in date of March 2024. You can `access previous documentation for translating the AM user interaface <https://archivematica.org/docs/latest/user-manual/translations/translations/>`.
 
 
 Enduro


### PR DESCRIPTION
Instead of using a specific locale and version, use the `latest/` endpoint instead for a more generic URL that will need less updates.