### PR TITLE
Enable button to view page on GitHub

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,3 +29,9 @@ html_static_path = ['_static']
 
 
 html_title = "Contributors Portal"
+
+html_theme_options = {
+    "source_repository": "https://github.com/artefactual/artefactual.github.io/",
+    "source_branch": "main",
+    "source_directory": "docs/",
+}


### PR DESCRIPTION
As mentioned in https://pradyunsg.me/furo/customisation/top-of-page-buttons/#with-popular-vcs-hosts